### PR TITLE
Adds missing ConfigurationParser file in META-INF/services.

### DIFF
--- a/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
+++ b/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
@@ -1,0 +1,1 @@
+org.infinispan.persistence.cloud.configuration.CloudStoreConfigurationParser72


### PR DESCRIPTION
The ConfigurationParser file points to CloudStoreConfigurationParser72, which is used to parse XML config in namespace `urn:infinispan:config:store:cloud:7.2`, including the cloud-store element. This is necessary to set up a cloud-store cache config via XML and have the correct parser be recognized by Infinispan.